### PR TITLE
Avoiding 2to3 to modify source (print function)

### DIFF
--- a/smem
+++ b/smem
@@ -8,6 +8,8 @@
 # the GNU General Public License version 2 or later, incorporated
 # herein by reference.
 
+from __future__ import print_function
+
 import re, os, sys, pwd, optparse, errno, tarfile
 
 warned = False


### PR DESCRIPTION
Added lines to avoid modifications if using 2to3 (indicating that print is already a function). At now, this is not needed for python2/python3 usage (since there is never a list in print), but it may cause problems when running with python2 if this is introduced in later modifications.